### PR TITLE
feat: add TS devOnlyServer plugin

### DIFF
--- a/TypeScript/devServerOnly.ts
+++ b/TypeScript/devServerOnly.ts
@@ -1,6 +1,6 @@
 // @ts-nocheck
 /**
- * Checks if the command is allowed in a specified server.
+ * Checks if a command is available in a specific server.
  *
  * @author @D3ord3NidAm [<@1017182455926624316>]
  * @version 1.0.0
@@ -10,9 +10,8 @@
  * import { devServerOnly } from "../plugins/devServerOnly";
  * export default commandModule({
  *   type: CommandType.Both,
- *   plugins: [devServerOnly(["guildId", "guildId"], "fail message")], // fail message is the message you will see when the command is ran in the wrong server.
+ *   plugins: [devServerOnly(["guildId"], failMessage)], // fail message is the message you will see when the command is ran in the wrong server.
  *   description: "command description",
- *
  *   execute: async (ctx, args) => {
  *     // your code here
  *   },
@@ -20,19 +19,24 @@
  * ```
  */
 
-
 import { CommandType, EventPlugin, PluginType } from "@sern/handler";
 
 export function devServerOnly(
   guildId: string[],
-  perFail: string
+  failMessage?: string
 ): EventPlugin<CommandType.Both> {
   return {
     type: PluginType.Event,
-    description: "Checks if the command is allowed in a specified server.",
+    description: "Checks if a command is available in a specific server.",
     async execute([ctx, args], controller) {
       if (!guildId.includes(ctx.guildId)) {
-        await ctx.reply(perFail);
+        if (!failMessage)
+          failMessage = "I am unable to comply with your command.";
+        await ctx.reply(failMessage).then(async (m) => {
+          setTimeout(async () => {
+            await m.delete();
+          }, 3000);
+        });
         return controller.stop();
       }
       return controller.next();

--- a/TypeScript/devServerOnly.ts
+++ b/TypeScript/devServerOnly.ts
@@ -1,0 +1,41 @@
+// @ts-nocheck
+/**
+ * Checks if the command is allowed in a specified server.
+ *
+ * @author @D3ord3NidAm [<@1017182455926624316>]
+ * @version 1.0.0
+ * @example
+ * ```ts
+ * import { commandModule, CommandType } from "@sern/handler";
+ * import { devServerOnly } from "../plugins/devServerOnly";
+ * export default commandModule({
+ *   type: CommandType.Both,
+ *   plugins: [devServerOnly(["guildId", "guildId"], "fail message")], // fail message is the message you will see when the command is ran in the wrong server.
+ *   description: "command description",
+ *
+ *   execute: async (ctx, args) => {
+ *     // your code here
+ *   },
+ * });
+ * ```
+ */
+
+
+import { CommandType, EventPlugin, PluginType } from "@sern/handler";
+
+export function devServerOnly(
+  guildId: string[],
+  perFail: string
+): EventPlugin<CommandType.Both> {
+  return {
+    type: PluginType.Event,
+    description: "Checks if the command is allowed in a specified server.",
+    async execute([ctx, args], controller) {
+      if (!guildId.includes(ctx.guildId)) {
+        await ctx.reply(perFail);
+        return controller.stop();
+      }
+      return controller.next();
+    },
+  };
+}

--- a/TypeScript/serverOnly.ts
+++ b/TypeScript/serverOnly.ts
@@ -7,7 +7,7 @@
  * @example
  * ```ts
  * import { commandModule, CommandType } from "@sern/handler";
- * import { devServerOnly } from "../plugins/devServerOnly";
+ * import { serverOnly } from "../plugins/serverOnly";
  * export default commandModule({
  *   type: CommandType.Both,
  *   plugins: [devServerOnly(["guildId"], failMessage)], // fail message is the message you will see when the command is ran in the wrong server.
@@ -21,7 +21,7 @@
 
 import { CommandType, EventPlugin, PluginType } from "@sern/handler";
 
-export function devServerOnly(
+export function serverOnly(
   guildId: string[],
   failMessage?: string
 ): EventPlugin<CommandType.Both> {

--- a/TypeScript/serverOnly.ts
+++ b/TypeScript/serverOnly.ts
@@ -10,7 +10,7 @@
  * import { serverOnly } from "../plugins/serverOnly";
  * export default commandModule({
  *   type: CommandType.Both,
- *   plugins: [devServerOnly(["guildId"], failMessage)], // fail message is the message you will see when the command is ran in the wrong server.
+ *   plugins: [serverOnly(["guildId"], failMessage)], // fail message is the message you will see when the command is ran in the wrong server.
  *   description: "command description",
  *   execute: async (ctx, args) => {
  *     // your code here

--- a/TypeScript/serverOnly.ts
+++ b/TypeScript/serverOnly.ts
@@ -23,15 +23,13 @@ import { CommandType, EventPlugin, PluginType } from "@sern/handler";
 
 export function serverOnly(
   guildId: string[],
-  failMessage?: string
+  failMessage = "I am unable to comply with your command."
 ): EventPlugin<CommandType.Both> {
   return {
     type: PluginType.Event,
     description: "Checks if a command is available in a specific server.",
     async execute([ctx, args], controller) {
       if (!guildId.includes(ctx.guildId)) {
-        if (!failMessage)
-          failMessage = "I am unable to comply with your command.";
         await ctx.reply(failMessage).then(async (m) => {
           setTimeout(async () => {
             await m.delete();


### PR DESCRIPTION
This plugin will send an error message when the command is ran outside of the specified guild id(s). If there is no `perFail` message provided, the code will provide an error.