### PR TITLE
Refactor: change default fail message and fix typo

### DIFF
--- a/TypeScript/serverOnly.ts
+++ b/TypeScript/serverOnly.ts
@@ -2,7 +2,7 @@
 /**
  * Checks if a command is available in a specific server.
  *
- * @author @DPeter-MJ-Parker [<@1017182455926624316>]
+ * @author @Peter-MJ-Parker [<@1017182455926624316>]
  * @version 1.0.0
  * @example
  * ```ts
@@ -23,7 +23,7 @@ import { CommandType, EventPlugin, PluginType } from "@sern/handler";
 
 export function serverOnly(
 	guildId: string[],
-	failMessage = "I am unable to comply with your command."
+	failMessage = "This command is not available in this guild. \nFor permission to use in your server, please contact my developer."
 ): EventPlugin<CommandType.Both> {
 	return {
 		type: PluginType.Event,


### PR DESCRIPTION
Original fail message may have been misleading to some people. They may have thought it was a complication with the bot and could lead to spamming of DMs to bot developer.  Fixed typo in my GitHub name after changing.