### PR TITLE
feat(filterA): filter autocomplete

### DIFF
--- a/plugins/filterA.ts
+++ b/plugins/filterA.ts
@@ -2,10 +2,10 @@ import { PluginType, makePlugin, controller, ControlPlugin } from "@sern/handler
 import type { AutocompleteInteraction } from 'discord.js'
 
 /**
- * @plugin
- * @author jacoobes
+ * @plugin 
+ * filters autocomplete interaction that pass the criteria
+ * @author jacoobes [<@182326315813306368>]
  * @version 1.0.0
- * @description filters autocomplete interaction that pass the criteria
  * @example
  * ```ts
  * import { CommandType, commandModule } from "@sern/handler";

--- a/plugins/filterA.ts
+++ b/plugins/filterA.ts
@@ -2,10 +2,10 @@ import { PluginType, makePlugin, controller, ControlPlugin } from "@sern/handler
 import type { AutocompleteInteraction } from 'discord.js'
 
 /**
+ * @plugin
  * @author jacoobes
  * @version 1.0.0
  * @description filters autocomplete interaction that pass the criteria
- * @license null
  * @example
  * ```ts
  * import { CommandType, commandModule } from "@sern/handler";
@@ -27,6 +27,7 @@ import type { AutocompleteInteraction } from 'discord.js'
  *    ],
  *    execute: (ctx, args) => {}
  * })
+ * @end
  */
 export const filterA = (pred: (value: string) => boolean) => {
     return makePlugin(PluginType.Control, (a: AutocompleteInteraction) => {

--- a/plugins/filterA.ts
+++ b/plugins/filterA.ts
@@ -1,0 +1,38 @@
+import { PluginType, makePlugin, controller, ControlPlugin } from "@sern/handler";
+import type { AutocompleteInteraction } from 'discord.js'
+
+/**
+ * @author jacoobes
+ * @version 1.0.0
+ * @description filters autocomplete interaction that pass the criteria
+ * @license null
+ * @example
+ * ```ts
+ * import { CommandType, commandModule } from "@sern/handler";
+ * import { filterA } from '../plugins/filterA.js'
+ * export default commandModule({
+ *    type : CommandType.Slash,
+ *    options: [
+ *       {  
+ *          autocomplete: true,
+ *          command : {
+ *             //only accept autocomplete interactions that include 'poo' in the text
+ *             onEvent: [filterA(s => s.includes('poo'))],
+ *             execute: (autocomplete) => {
+ *                let data = [{ name: 'pooba', value: 'first' }, { name: 'pooga', value: 'second' }]
+ *                autocomplete.respond(data) 
+ *             }
+ *          }
+ *       }
+ *    ],
+ *    execute: (ctx, args) => {}
+ * })
+ */
+export const filterA = (pred: (value: string) => boolean) => {
+    return makePlugin(PluginType.Control, (a: AutocompleteInteraction) => {
+        if(pred(a.options.getFocused())) {
+            return controller.next();
+        }
+        return controller.stop();
+    }) as ControlPlugin;
+}


### PR DESCRIPTION
## Plugin Submission Checklist

Before submitting your plugin, please ensure that you have followed the specifications below:

- [x] Your plugin code includes a JSDoc block with `@plugin` at the beginning and `@end` at the end.
- [x] The order of plugin metadata within the JSDoc block follows the structure provided:
  1. `@plugin`
  2. `description`
  3. `@author` (you can have multiple authors in this format: `@author  @jacoobes [<@182326315813306368>]`)
  4. `@version` (with the version number)
  5. `@example` (a nice example of how to use your plugin)
  6. `@end`

## Plugin Submission Details

**Description:**

This is the filterA plugin which is a simple plugin for autocomplete interaction

**Authors:**

_[List the authors of the plugin along with their Discord IDs in the format `@username [<@discord_id>]`. You can add multiple authors in this manner.]_

**Version:**

_[Specify the version number of your plugin.]_

**Example:**

_[Provide an example of how your plugin can be used here.]_

## Additional Notes

_[Include any additional information or notes you'd like to provide regarding your plugin submission.]_

