### PR TITLE
fix: deprecated enums by discord.js

### DIFF
--- a/plugins/nsfwOnly.ts
+++ b/plugins/nsfwOnly.ts
@@ -5,7 +5,7 @@
  *
  * @author @Benzo-Fury [<@762918086349029386>]
  * @author @SrIzan10 [<@703974042700611634>]
- * @version 1.0.0
+ * @version 1.0.1
  * @example
  * ```ts
  * import { nsfwOnly } from "../plugins/nsfwOnly";

--- a/plugins/nsfwOnly.ts
+++ b/plugins/nsfwOnly.ts
@@ -4,6 +4,7 @@
  * This plugin checks if the channel is nsfw and responds to user with a specified response if not nsfw
  *
  * @author @Benzo-Fury [<@762918086349029386>]
+ * @author @SrIzan10 [<@703974042700611634>]
  * @version 1.0.0
  * @example
  * ```ts
@@ -29,8 +30,8 @@ function isGuildText(
 	channel: TextBasedChannel | null,
 ): channel is GuildTextBasedChannel {
 	return (
-		channel?.type == ChannelType.GuildPublicThread ||
-		channel?.type == ChannelType.GuildPrivateThread
+		channel?.type == ChannelType.PublicThread ||
+		channel?.type == ChannelType.PrivateThread
 	);
 }
 export function nsfwOnly(onFail: string, ephemeral: boolean) {


### PR DESCRIPTION
## Plugin Submission Checklist

Before submitting your plugin, please ensure that you have followed the specifications below:

- [x] Your plugin code includes a JSDoc block with `@plugin` at the beginning and `@end` at the end.
- [x] The order of plugin metadata within the JSDoc block follows the structure provided:
  1. `@plugin`
  2. `description`
  3. `@author` (you can have multiple authors in this format: `@author  @jacoobes [<@182326315813306368>]`)
  4. `@version` (with the version number)
  5. `@example` (a nice example of how to use your plugin)
  6. `@end`

this is an example:
```js
/** 
 * @plugin
 * filters autocomplete interaction that pass the criteria
 * @author @jacoobes [<@182326315813306368>]
 * @version 1.0.0
 * @example
 * ```ts
 * import { CommandType, commandModule } from "@sern/handler";
 * import { filterA } from '../plugins/filterA.js'
 * export default commandModule({
 *    type : CommandType.Slash,
 *    options: [
 *       {  
 *          autocomplete: true,
 *          command : {
 *             //only accept autocomplete interactions that include 'poo' in the text
 *             onEvent: [filterA(s => s.includes('poo'))],
 *             execute: (autocomplete) => {
 *                let data = [{ name: 'pooba', value: 'first' }, { name: 'pooga', value: 'second' }]
 *                autocomplete.respond(data) 
 *             }
 *          }
 *       }
 *    ],
 *    execute: (ctx, args) => {}
 * })
 * @end
 */


```

## Plugin Submission Details
fixes some deprecated enums on newer versions of d.js
## Additional Notes
no