### PR TITLE
chore: update disable.ts

### DIFF
--- a/plugins/disable.ts
+++ b/plugins/disable.ts
@@ -1,11 +1,11 @@
-// @ts-nocheck
+//@ts-nocheck
 /**
  * @plugin
  * Disables a command entirely, for whatever reasons you may need.
  *
  * @author @jacoobes [<@182326315813306368>]
  * @author @Peter-MJ-Parker [<@371759410009341952>]
- * @version 2.0.0
+ * @version 2.1.0
  * @example
  * ```ts
  * import { disable } from "../plugins/disable";
@@ -20,36 +20,49 @@
  * @end
  */
 import { CommandType, CommandControlPlugin, controller } from "@sern/handler";
-import { InteractionReplyOptions, ReplyMessageOptions } from "discord.js";
+import { InteractionReplyOptions, MessageReplyOptions } from "discord.js";
 
 export function disable(
 	onFail?:
 		| string
 		| Omit<InteractionReplyOptions, "fetchReply">
-		| ReplyMessageOptions,
+		| MessageReplyOptions
 ) {
 	return CommandControlPlugin<CommandType.Both>(async (ctx, [args]) => {
 		if (onFail !== undefined) {
 			switch (args) {
 				case "text":
-					//reply to text command
-					const msg = await ctx.reply(onFail);
-					setTimeout(() => {
-						//deletes the bots reply to the user
-						msg.delete();
-						//deletes the original authors message (text command).
-						ctx.message.delete();
-						//waits 5 seconds before deleting messages
-					}, 5000).catch((e) => {
-						//logs error to console (if any).
-						console.log(e);
-					});
+					try {
+						//reply to text command
+						const msg = await ctx.reply(onFail);
+						setTimeout(() => {
+							//deletes the bots reply to the user
+							msg.delete();
+							//deletes the original authors message (text command).
+							ctx.message.delete();
+							//waits 5 seconds before deleting messages
+						}, 5000);
+					} catch (error) {
+						console.log(
+							"Could not delete disabled response due to: " +
+								error
+						);
+					}
 
 					break;
 
 				case "slash":
-					//ephemeral response to say the command is disabled with users response.
-					await ctx.reply({ content: onFail, ephemeral: true });
+					//response to say the command is disabled with users response.
+					let reply = await ctx.reply(onFail);
+					try {
+						setTimeout(async () => {
+							await reply.delete();
+						}, 5000);
+					} catch (error) {
+						console.log(
+							"Could not delete disabled response due to it being ephemeral."
+						);
+					}
 					break;
 
 				default:


### PR DESCRIPTION
Noticed a few bugs.
1) Changed invalid import from discord.js. Implicitly had an any type for `onFail`.
```diff
-ReplyMessageOptions
+MessageReplyOptions
```
2) Corrected the improper catching of errors by implementing try/catch blocks. Included more detailed error responses. 
3) Default reply for slash with onFail inputted was invalid because it could also be a string.

## Plugin Submission Checklist

Before submitting your plugin, please ensure that you have followed the specifications below:

- [x] Your plugin code includes a JSDoc block with `@plugin` at the beginning and `@end` at the end.
- [x] The order of plugin metadata within the JSDoc block follows the structure provided:
  1. `@plugin`
  2. `description`
  3. `@author` (you can have multiple authors in this format: `@author  @jacoobes [<@182326315813306368>]`)
  4. `@version` (with the version number)
  5. `@example` (a nice example of how to use your plugin)
  6. `@end`

this is an example:
```js
/** 
 * @plugin
 * filters autocomplete interaction that pass the criteria
 * @author @jacoobes [<@182326315813306368>]
 * @version 1.0.0
 * @example
 * ```ts
 * import { CommandType, commandModule } from "@sern/handler";
 * import { filterA } from '../plugins/filterA.js'
 * export default commandModule({
 *    type : CommandType.Slash,
 *    options: [
 *       {  
 *          autocomplete: true,
 *          command : {
 *             //only accept autocomplete interactions that include 'poo' in the text
 *             onEvent: [filterA(s => s.includes('poo'))],
 *             execute: (autocomplete) => {
 *                let data = [{ name: 'pooba', value: 'first' }, { name: 'pooga', value: 'second' }]
 *                autocomplete.respond(data) 
 *             }
 *          }
 *       }
 *    ],
 *    execute: (ctx, args) => {}
 * })
 * @end
 */


```

## Plugin Submission Details
[Enter data here] this is optional
## Additional Notes

_[Include any additional information or notes you'd like to provide regarding your plugin submission.]_

When running this plugin before, I got errors showing types were any or incompatible due to the import from discord.js. Then it couldn't catch the errors from setTimeout because they were being caught improperly and bot would crash. After these changes were implemented, the plugin no longer errors out.