### PR TITLE
chore: Update permCheck.ts

### DIFF
--- a/plugins/permCheck.ts
+++ b/plugins/permCheck.ts
@@ -11,13 +11,12 @@
  * ```ts
  * import { permCheck } from "../plugins/permCheck";
  * import { commandModule } from "@sern/handler";
- * import { PermissionFlagsBits } from "discord.js";
  * export default commandModule({
  *  plugins: [
- * 		//permCheck.command("permission", "response")
- * 		//permCheck.subGroups([{ name: "test", perms: <Permissions>, needAllPerms: boolean, response?: "set me for custom response"}, { ...other_group_setup }])
- * 		//permCheck.subcommands([ { name: "testAgain", ...same options }, { ... } ])
- * 		//permCheck.options([ {}, {} ]) WIP!
+ * 		permCheck("command", ["Administrator", "AddReactions"], "I am a custom response!"),
+ * 		permCheck("options", [{ name: "user", needAllPerms: true, perms: ["AttachFiles", "CreateEvents"]}]),
+ * 		permCheck("subcommands", [{ name: "list", needAllPerms: false, perms: ["Connect"]}]),
+ * 		permCheck("subGroups", [{ name: "list", needAllPerms: false, perms: ["Connect"], response: "I am also a custom response!"}])
  * 	],
  *  execute: (ctx) => {
  * 		//your code here
@@ -28,246 +27,297 @@
  */
 
 import {
-  Colors,
-  EmbedBuilder,
-  PermissionsBitField,
-  type GuildMember,
-  type PermissionResolvable,
-  type TextChannel
+	ChatInputCommandInteraction,
+	Colors,
+	EmbedBuilder,
+	PermissionsBitField,
+	type GuildMember,
+	type PermissionResolvable,
+	type TextChannel,
 } from "discord.js";
 import {
-  CommandControlPlugin,
-  CommandType,
-  controller,
-  Service
+	CommandControlPlugin,
+	CommandType,
+	controller,
+	Service,
 } from "@sern/handler";
 
 function command(perm: PermissionResolvable, response?: string) {
-  return CommandControlPlugin<CommandType.Both>(async (ctx) => {
-    if (ctx.guild === null) {
-      await ctx.reply("This command cannot be used in DM's!");
-      return controller.stop();
-    }
-    if (
-      !(ctx.member! as GuildMember)
-        .permissionsIn(ctx.channel as TextChannel)
-        .has(perm)
-    ) {
-      await ctx.reply({
-        embeds: [
-          sendEmbed(
-            response ??
-              `You are missing required permissions to run this command:\n${permsToString(perm)}`
-          )
-        ],
-        ephemeral: ctx.isMessage() ? false : true
-      });
-      return controller.stop();
-    }
-    if (
-      !(ctx.member! as GuildMember)
-        .permissionsIn(ctx.channel as TextChannel)
-        .any(perm)
-    ) {
-      await ctx.reply({
-        embeds: [
-          sendEmbed(
-            response ??
-              `You need at least one of the following permissions to run this command:\n${permsToString(perm)}`
-          )
-        ],
-        ephemeral: ctx.isMessage() ? false : true
-      });
-      return controller.stop();
-    }
-    return controller.next();
-  });
+	return CommandControlPlugin<CommandType.Both>(async (ctx) => {
+		if (ctx.guild === null) {
+			await ctx.reply("This command cannot be used in DM's!");
+			return controller.stop();
+		}
+		if (
+			!(ctx.member! as GuildMember)
+				.permissionsIn(ctx.channel as TextChannel)
+				.has(perm)
+		) {
+			await ctx.reply({
+				embeds: [
+					sendEmbed(
+						response ??
+							`You are missing required permissions to run this command:\n${permsToString(
+								perm
+							)}`
+					),
+				],
+				ephemeral: !ctx.isMessage() ? true : false,
+			});
+			return controller.stop();
+		}
+		if (
+			!(ctx.member! as GuildMember)
+				.permissionsIn(ctx.channel as TextChannel)
+				.any(perm)
+		) {
+			await ctx.reply({
+				embeds: [
+					sendEmbed(
+						response ??
+							`You need at least one of the following permissions to run this command:\n${permsToString(
+								perm
+							)}`
+					),
+				],
+				ephemeral: ctx.isMessage() ? false : true,
+			});
+			return controller.stop();
+		}
+		return controller.next();
+	});
 }
 function subGroups(opts: BaseOptions[]) {
-  return CommandControlPlugin<CommandType.Slash>(async ({ interaction }) => {
-    await no_guild(interaction);
-    const member = interaction.member as GuildMember;
-    const group = interaction.options.getSubcommandGroup();
-    for (const opt of opts) {
-      if (group !== opt.name) {
-        await interaction.reply({
-          embeds: [
-            sendEmbed(
-              `[PLUGIN_permCheck.subGroups]: Failed to find specified subcommandGroup \`${opt.name}\`!`
-            )
-          ],
-          ephemeral: true
-        });
-        return controller.stop();
-      }
-      const _perms = member.permissionsIn(interaction.channel as TextChannel);
-      if (opt.needAllPerms && !_perms.has(opt.perms)) {
-        await interaction.reply({
-          embeds: [
-            sendEmbed(
-              opt.response ??
-                `You cannot use this group due to missing permissions: ${permsToString(opt.perms)}`
-            )
-          ],
-          ephemeral: true
-        });
-        return controller.stop();
-      }
-      if (!opt.needAllPerms && !_perms.any(opt.perms)) {
-        await interaction.reply({
-          embeds: [
-            sendEmbed(
-              opt.response ??
-                `You cannot use this group because you need at least one of the following permissions: ${permsToString(opt.perms)}`
-            )
-          ],
-          ephemeral: true
-        });
-        return controller.stop();
-      }
-    }
-    return controller.next();
-  });
+	return CommandControlPlugin<CommandType.Slash>(async ({ interaction }) => {
+		await no_guild(interaction);
+		const member = interaction.member as GuildMember;
+		const group = interaction.options.getSubcommandGroup();
+		for (const opt of opts) {
+			if (group !== opt.name) {
+				await interaction.reply({
+					embeds: [
+						sendEmbed(
+							`[PLUGIN_permCheck.subGroups]: Failed to find specified subcommandGroup \`${opt.name}\`!`
+						),
+					],
+					ephemeral: true,
+				});
+				return controller.stop();
+			}
+			const _perms = member.permissionsIn(
+				interaction.channel as TextChannel
+			);
+			if (opt.needAllPerms && !_perms.has(opt.perms)) {
+				await interaction.reply({
+					embeds: [
+						sendEmbed(
+							opt.response ??
+								`You cannot use this group due to missing permissions: ${permsToString(
+									opt.perms
+								)}`
+						),
+					],
+					ephemeral: true,
+				});
+				return controller.stop();
+			}
+			if (!opt.needAllPerms && !_perms.any(opt.perms)) {
+				await interaction.reply({
+					embeds: [
+						sendEmbed(
+							opt.response ??
+								`You cannot use this group because you need at least one of the following permissions: ${permsToString(
+									opt.perms
+								)}`
+						),
+					],
+					ephemeral: true,
+				});
+				return controller.stop();
+			}
+		}
+		return controller.next();
+	});
 }
 
 function subcommands(opts: BaseOptions[]) {
-  return CommandControlPlugin<CommandType.Slash>(async ({ interaction }) => {
-    await no_guild(interaction);
-    const member = interaction.member as GuildMember;
-    const sub = interaction.options.getSubcommand();
-    for (const opt of opts) {
-      if (sub !== opt.name) {
-        await interaction.reply({
-          embeds: [
-            sendEmbed(
-              `[PLUGIN_permCheck.subcommands]: Failed to find specified subcommand \`${opt.name}\`!`
-            )
-          ],
-          ephemeral: true
-        });
-        return controller.stop();
-      }
-      const _perms = member.permissionsIn(interaction.channel as TextChannel);
-      if (opt.needAllPerms && !_perms.has(opt.perms)) {
-        await interaction.reply({
-          embeds: [
-            sendEmbed(
-              opt.response ??
-                `You cannot use this subcommand due to missing permissions: ${permsToString(opt.perms)}`
-            )
-          ],
-          ephemeral: true
-        });
-        return controller.stop();
-      }
-      if (!opt.needAllPerms && !_perms.any(opt.perms)) {
-        await interaction.reply({
-          embeds: [
-            sendEmbed(
-              opt.response ??
-                `You cannot use this subcommand because you need at least one of the following permissions: ${permsToString(opt.perms)}`
-            )
-          ],
-          ephemeral: true
-        });
-        return controller.stop();
-      }
-    }
-    return controller.next();
-  });
+	return CommandControlPlugin<CommandType.Slash>(async ({ interaction }) => {
+		await no_guild(interaction);
+		const member = interaction.member as GuildMember;
+		const sub = interaction.options.getSubcommand();
+		for (const opt of opts) {
+			if (sub !== opt.name) {
+				await interaction.reply({
+					embeds: [
+						sendEmbed(
+							`[PLUGIN_permCheck.subcommands]: Failed to find specified subcommand \`${opt.name}\`!`
+						),
+					],
+					ephemeral: true,
+				});
+				return controller.stop();
+			}
+			const _perms = member.permissionsIn(
+				interaction.channel as TextChannel
+			);
+			if (opt.needAllPerms && !_perms.has(opt.perms)) {
+				await interaction.reply({
+					embeds: [
+						sendEmbed(
+							opt.response ??
+								`You cannot use this subcommand due to missing permissions: ${permsToString(
+									opt.perms
+								)}`
+						),
+					],
+					ephemeral: true,
+				});
+				return controller.stop();
+			}
+			if (!opt.needAllPerms && !_perms.any(opt.perms)) {
+				await interaction.reply({
+					embeds: [
+						sendEmbed(
+							opt.response ??
+								`You cannot use this subcommand because you need at least one of the following permissions: ${permsToString(
+									opt.perms
+								)}`
+						),
+					],
+					ephemeral: true,
+				});
+				return controller.stop();
+			}
+		}
+		return controller.next();
+	});
 }
 function options(opts: BaseOptions[]) {
-  return CommandControlPlugin<CommandType.Slash>(async ({ interaction }) => {
-    await no_guild(interaction);
-    const member = interaction.member as GuildMember;
-    const channel = interaction.channel as TextChannel;
+	return CommandControlPlugin<CommandType.Slash>(async ({ interaction }) => {
+		await no_guild(interaction);
+		const member = interaction.member as GuildMember;
+		const channel = interaction.channel as TextChannel;
 
-    for (const opt of opts) {
-      const option = interaction.options.get(opt.name);
-      console.log(option);
+		for (const opt of opts) {
+			const option = interaction.options.get(opt.name);
+			console.log(option);
 
-      if (option && option.name !== opt.name) {
-        await interaction.reply({
-          embeds: [
-            sendEmbed(
-              `[PLUGIN_permCheck.options]: Could not find supplied option: \`${opt.name}\``
-            )
-          ],
-          ephemeral: true
-        });
-        return controller.stop();
-      }
+			if (option && option.name !== opt.name) {
+				await interaction.reply({
+					embeds: [
+						sendEmbed(
+							`[PLUGIN_permCheck.options]: Could not find supplied option: \`${opt.name}\``
+						),
+					],
+					ephemeral: true,
+				});
+				return controller.stop();
+			}
 
-      const permissions = member.permissionsIn(channel);
+			const permissions = member.permissionsIn(channel);
 
-      console.log(permsToString(permissions));
-      if (opt.needAllPerms) {
-        if (!permissions.has(opt.perms)) {
-          await interaction.reply({
-            embeds: [
-              sendEmbed(
-                opt.response ??
-                  `You need all the following permissions for option \`${opt.name}\`:\n ${permsToString(...opt.perms)}`
-              )
-            ],
-            ephemeral: true
-          });
-          return controller.stop();
-        }
-      } else {
-        if (!permissions.any(opt.perms)) {
-          await interaction.reply({
-            embeds: [
-              sendEmbed(
-                opt.response ??
-                  `You need at least one of the following permissions for option \`${opt.name}\`: \n${permsToString(...opt.perms)}`
-              )
-            ],
-            ephemeral: true
-          });
-          return controller.stop();
-        }
-      }
-    }
+			console.log(permsToString(permissions));
+			if (opt.needAllPerms) {
+				if (!permissions.has(opt.perms)) {
+					await interaction.reply({
+						embeds: [
+							sendEmbed(
+								opt.response ??
+									`You need all the following permissions for option \`${
+										opt.name
+									}\`:\n ${permsToString(...opt.perms)}`
+							),
+						],
+						ephemeral: true,
+					});
+					return controller.stop();
+				}
+			} else {
+				if (!permissions.any(opt.perms)) {
+					await interaction.reply({
+						embeds: [
+							sendEmbed(
+								opt.response ??
+									`You need at least one of the following permissions for option \`${
+										opt.name
+									}\`: \n${permsToString(...opt.perms)}`
+							),
+						],
+						ephemeral: true,
+					});
+					return controller.stop();
+				}
+			}
+		}
 
-    return controller.next();
-  });
+		return controller.next();
+	});
 }
 interface BaseOptions {
-  name: string;
-  perms: PermissionResolvable[];
-  needAllPerms: boolean;
-  response?: string;
+	name: string;
+	perms: PermissionResolvable[];
+	needAllPerms: boolean;
+	response?: string;
 }
 
-const no_guild = async (interaction: any) => {
-  if (interaction.guild === null) {
-    await interaction.reply({
-      content: "This command cannot be used in DM's!",
-      ephemeral: true
-    });
-    return controller.stop();
-  }
+const no_guild = async (interaction: ChatInputCommandInteraction) => {
+	if (interaction.guild === null) {
+		await interaction.reply({
+			content: "This command cannot be used in DM's!",
+			ephemeral: true,
+		});
+		return controller.stop();
+	}
 };
 
 const sendEmbed = (description: string) => {
-  const client = Service("@sern/client");
-  return new EmbedBuilder({
-    title: ":x: Permission Error! :x:",
-    description,
-    color: Colors.Red,
-    footer: {
-      text: client.user?.username!,
-      icon_url: client.user?.displayAvatarURL()!
-    }
-  });
+	const client = Service("@sern/client");
+	return new EmbedBuilder({
+		title: ":x: Permission Error! :x:",
+		description,
+		color: Colors.Red,
+		footer: {
+			text: client.user?.username!,
+			icon_url: client.user?.displayAvatarURL()!,
+		},
+	});
 };
 
 export const permsToString = (...perms: PermissionResolvable[]) => {
-  return new PermissionsBitField(perms)
-    .toArray()
-    .map((perm) => `\`${perm}\``)
-    .join(", ");
+	return new PermissionsBitField(perms)
+		.toArray()
+		.map((perm) => `\`${perm}\``)
+		.join(", ");
 };
 
-export const permCheck = { command, options, subcommands, subGroups };
+export function permCheck(
+	type: "command",
+	perm: PermissionResolvable,
+	response?: string
+): ReturnType<typeof command>;
+export function permCheck(
+	type: "subGroups" | "subcommands" | "options",
+	opts: BaseOptions[]
+):
+	| ReturnType<typeof subGroups>
+	| ReturnType<typeof subcommands>
+	| ReturnType<typeof options>;
+
+export function permCheck(
+	type: "command" | "subGroups" | "subcommands" | "options",
+	permissionsOrOpts: PermissionResolvable | BaseOptions[],
+	response?: string
+) {
+	switch (type) {
+		case "command":
+			return command(permissionsOrOpts as PermissionResolvable, response);
+		case "subGroups":
+			return subGroups(permissionsOrOpts as BaseOptions[]);
+		case "subcommands":
+			return subcommands(permissionsOrOpts as BaseOptions[]);
+		case "options":
+			return options(permissionsOrOpts as BaseOptions[]);
+		default:
+			throw new Error(`Unknown type: ${type}`);
+	}
+}

--- a/plugins/permCheck.ts
+++ b/plugins/permCheck.ts
@@ -200,7 +200,6 @@ function options(opts: BaseOptions[]) {
 
 		for (const opt of opts) {
 			const option = interaction.options.get(opt.name);
-			console.log(option);
 
 			if (option && option.name !== opt.name) {
 				await interaction.reply({
@@ -216,7 +215,6 @@ function options(opts: BaseOptions[]) {
 
 			const permissions = member.permissionsIn(channel);
 
-			console.log(permsToString(permissions));
 			if (opt.needAllPerms) {
 				if (!permissions.has(opt.perms)) {
 					await interaction.reply({

--- a/plugins/permCheck.ts
+++ b/plugins/permCheck.ts
@@ -77,7 +77,7 @@ function subGroups(opts: BaseOptions[]) {
 	return CommandControlPlugin<CommandType.Slash>(async (ctx) => {
 		if (ctx.guild === null) {
 			await ctx.reply({
-				content: "This command cannot be used in DM's!",
+				content: "This sub command group cannot be used in DM's!",
 				ephemeral: !ctx.isMessage(),
 			});
 			return controller.stop();
@@ -122,7 +122,7 @@ function subcommands(opts: BaseOptions[]) {
 	return CommandControlPlugin<CommandType.Slash>(async (ctx) => {
 		if (ctx.guild === null) {
 			await ctx.reply({
-				content: "This command cannot be used in DM's!",
+				content: "This sub command cannot be used in DM's!",
 				ephemeral: !ctx.isMessage(),
 			});
 			return controller.stop();
@@ -166,7 +166,7 @@ function options(opts: BaseOptions[]) {
 	return CommandControlPlugin<CommandType.Slash>(async (ctx) => {
 		if (ctx.guild === null) {
 			await ctx.reply({
-				content: "This command cannot be used in DM's!",
+				content: "This specific option cannot be used in DM's!",
 				ephemeral: !ctx.isMessage(),
 			});
 			return controller.stop();

--- a/plugins/permCheck.ts
+++ b/plugins/permCheck.ts
@@ -119,7 +119,7 @@ function subGroups(opts: BaseOptions[]) {
 }
 
 function subcommands(opts: BaseOptions[]) {
-	return CommandControlPlugin<CommandType.Slash>(async ({ ctx }) => {
+	return CommandControlPlugin<CommandType.Slash>(async (ctx) => {
 		if (ctx.guild === null) {
 			await ctx.reply({
 				content: "This command cannot be used in DM's!",
@@ -163,7 +163,7 @@ function subcommands(opts: BaseOptions[]) {
 	});
 }
 function options(opts: BaseOptions[]) {
-	return CommandControlPlugin<CommandType.Slash>(async ({ ctx }) => {
+	return CommandControlPlugin<CommandType.Slash>(async (ctx) => {
 		if (ctx.guild === null) {
 			await ctx.reply({
 				content: "This command cannot be used in DM's!",

--- a/plugins/permCheck.ts
+++ b/plugins/permCheck.ts
@@ -12,12 +12,10 @@
  * import { permCheck } from "../plugins/permCheck";
  * import { commandModule } from "@sern/handler";
  * export default commandModule({
- *  plugins: [
- * 		permCheck("command", ["Administrator", "AddReactions"], "I am a custom response!"),
- * 		permCheck("options", [{ name: "user", needAllPerms: true, perms: ["AttachFiles", "CreateEvents"]}]),
- * 		permCheck("subcommands", [{ name: "list", needAllPerms: false, perms: ["Connect"]}]),
- * 		permCheck("subGroups", [{ name: "list", needAllPerms: false, perms: ["Connect"], response: "I am also a custom response!"}])
- * 	],
+ *  plugins: [ permCheck(["Administrator", "AddReactions"], "I am a custom response!"),
+ * 		permCheck.options([{ name: "user", needAllPerms: true, perms: ["AttachFiles", "CreateEvents"]}]),
+ * 		permCheck.subcommands([{ name: "list", needAllPerms: false, perms: ["Connect"]}]),
+ * 		permCheck.subGroups([{ name: "list", needAllPerms: false, perms: ["Connect"], response: "I am also a custom response!"}])],
  *  execute: (ctx) => {
  * 		//your code here
  *  }
@@ -27,249 +25,242 @@
  */
 
 import {
-	ChatInputCommandInteraction,
-	Colors,
-	EmbedBuilder,
-	PermissionsBitField,
-	type GuildMember,
-	type PermissionResolvable,
-	type TextChannel,
-} from "discord.js";
-import {
-	CommandControlPlugin,
-	type CommandType,
-	controller,
-	Service,
-} from "@sern/handler";
+  Colors,
+  EmbedBuilder,
+  PermissionsBitField,
+  type GuildMember,
+  type PermissionResolvable,
+  type TextChannel
+} from 'discord.js';
+import { CommandControlPlugin, type CommandType, controller, Service } from '@sern/handler';
 
 function command(perm: PermissionResolvable, response?: string) {
-	return CommandControlPlugin<CommandType.Both>(async (ctx) => {
-		if (ctx.guild === null) {
-			await ctx.reply({
-				content: "This command cannot be used in DM's!", 
-				ephemeral: !ctx.isMessage()
-			});
-			return controller.stop();
-		}
-		const _perms = (ctx.member as GuildMember).permissionsIn(ctx.channel as TextChannel);
-		if (!_perms.has(perm)) {
-			await ctx.reply({
-				embeds: [
-					sendEmbed(response ?? `You are missing required permissions to run this command:\n${permsToString(perm)}`),
-				],
-				ephemeral: !ctx.isMessage(),
-			});
-			return controller.stop();
-		}
-		if (!_perms.any(perm)) {
-			await ctx.reply({
-				embeds: [
-					sendEmbed(response ?? `You need at least one of the following permissions to run this command:\n${permsToString(perm)}`),
-				],
-				ephemeral: !ctx.isMessage(),
-			});
-			return controller.stop();
-		}
-		return controller.next();
-	});
+  return CommandControlPlugin<CommandType.Both>(async (ctx) => {
+    if (ctx.guild === null) {
+      await ctx.reply({
+        content: "This command cannot be used in DM's!",
+        ephemeral: !ctx.isMessage()
+      });
+      return controller.stop();
+    }
+    const _perms = (ctx.member as GuildMember).permissionsIn(ctx.channel as TextChannel);
+    if (!_perms.has(perm)) {
+      await ctx.reply({
+        embeds: [
+          sendEmbed(response ?? `You are missing required permissions to run this command:\n${permsToString(perm)}`)
+        ],
+        ephemeral: !ctx.isMessage()
+      });
+      return controller.stop();
+    }
+    if (!_perms.any(perm)) {
+      await ctx.reply({
+        embeds: [
+          sendEmbed(
+            response ??
+              `You need at least one of the following permissions to run this command:\n${permsToString(perm)}`
+          )
+        ],
+        ephemeral: !ctx.isMessage()
+      });
+      return controller.stop();
+    }
+    return controller.next();
+  });
 }
 function subGroups(opts: BaseOptions[]) {
-	return CommandControlPlugin<CommandType.Slash>(async (ctx) => {
-		if (ctx.guild === null) {
-			await ctx.reply({
-				content: "This sub command group cannot be used in DM's!",
-				ephemeral: !ctx.isMessage(),
-			});
-			return controller.stop();
-		}
-		const member = ctx.member as GuildMember;
-		const group = ctx.options.getSubcommandGroup();
-		for (const opt of opts) {
-			if (group !== opt.name) {
-				await ctx.reply({
-					embeds: [
-						sendEmbed(`[PLUGIN_permCheck.subGroups]: Failed to find specified subcommandGroup \`${opt.name}\`!`),
-					],
-					ephemeral: !ctx.isMessage(),
-				});
-				return controller.stop();
-			}
-			const _perms = member.permissionsIn(ctx.channel as TextChannel);
-			if (opt.needAllPerms && !_perms.has(opt.perms)) {
-				await ctx.reply({
-					embeds: [
-						sendEmbed(opt.response ??	`You cannot use this group due to missing permissions: ${permsToString(opt.perms)}`),
-					],
-					ephemeral: !ctx.isMessage(),
-				});
-				return controller.stop();
-			}
-			if (!opt.needAllPerms && !_perms.any(opt.perms)) {
-				await ctx.reply({
-					embeds: [
-						sendEmbed(opt.response ?? `You cannot use this group because you need at least one of the following permissions: ${permsToString(opt.perms)}`),
-					],
-					ephemeral: !ctx.isMessage(),
-				});
-				return controller.stop();
-			}
-		}
-		return controller.next();
-	});
+  return CommandControlPlugin<CommandType.Slash>(async (ctx) => {
+    if (ctx.guild === null) {
+      await ctx.reply({
+        content: "This sub command group cannot be used in DM's!",
+        ephemeral: !ctx.isMessage()
+      });
+      return controller.stop();
+    }
+    const member = ctx.member as GuildMember;
+    const group = ctx.options.getSubcommandGroup();
+    for (const opt of opts) {
+      if (group !== opt.name) {
+        await ctx.reply({
+          embeds: [
+            sendEmbed(`[PLUGIN_permCheck.subGroups]: Failed to find specified subcommandGroup \`${opt.name}\`!`)
+          ],
+          ephemeral: !ctx.isMessage()
+        });
+        return controller.stop();
+      }
+      const _perms = member.permissionsIn(ctx.channel as TextChannel);
+      if (opt.needAllPerms && !_perms.has(opt.perms)) {
+        await ctx.reply({
+          embeds: [
+            sendEmbed(
+              opt.response ?? `You cannot use this group due to missing permissions: ${permsToString(opt.perms)}`
+            )
+          ],
+          ephemeral: !ctx.isMessage()
+        });
+        return controller.stop();
+      }
+      if (!opt.needAllPerms && !_perms.any(opt.perms)) {
+        await ctx.reply({
+          embeds: [
+            sendEmbed(
+              opt.response ??
+                `You cannot use this group because you need at least one of the following permissions: ${permsToString(
+                  opt.perms
+                )}`
+            )
+          ],
+          ephemeral: !ctx.isMessage()
+        });
+        return controller.stop();
+      }
+    }
+    return controller.next();
+  });
 }
 
 function subcommands(opts: BaseOptions[]) {
-	return CommandControlPlugin<CommandType.Slash>(async (ctx) => {
-		if (ctx.guild === null) {
-			await ctx.reply({
-				content: "This sub command cannot be used in DM's!",
-				ephemeral: !ctx.isMessage(),
-			});
-			return controller.stop();
-		}
-		const member = ctx.member as GuildMember;
-		const sub = ctx.options.getSubcommand();
-		for (const { name, needAllPerms, perms, response } of opts) {
-			if (sub !== name) {
-				await ctx.reply({
-					embeds: [
-						sendEmbed(`[PLUGIN_permCheck.subcommands]: Failed to find specified subcommand \`${name}\`!`),
-					],
-					ephemeral: !ctx.isMessage(),
-				});
-				return controller.stop();
-			}
-			const _perms = member.permissionsIn(ctx.channel as TextChannel);
-			if (needAllPerms && !_perms.has(perms)) {
-				await ctx.reply({
-					embeds: [
-						sendEmbed(response ?? `You cannot use this subcommand due to missing permissions: ${permsToString(perms)}`),
-					],
-					ephemeral: !ctx.isMessage(),
-				});
-				return controller.stop();
-			}
-			if (!needAllPerms && !_perms.any(perms)) {
-				await ctx.reply({
-					embeds: [
-						sendEmbed(response ?? `You cannot use this subcommand because you need at least the following permissions: ${permsToString(perms)}`),
-					],
-					ephemeral: !ctx.isMessage(),
-				});
-				return controller.stop();
-			}
-		}
-		return controller.next();
-	});
+  return CommandControlPlugin<CommandType.Slash>(async (ctx) => {
+    if (ctx.guild === null) {
+      await ctx.reply({
+        content: "This sub command cannot be used in DM's!",
+        ephemeral: !ctx.isMessage()
+      });
+      return controller.stop();
+    }
+    const member = ctx.member as GuildMember;
+    const sub = ctx.options.getSubcommand();
+    for (const { name, needAllPerms, perms, response } of opts) {
+      if (sub !== name) {
+        await ctx.reply({
+          embeds: [sendEmbed(`[PLUGIN_permCheck.subcommands]: Failed to find specified subcommand \`${name}\`!`)],
+          ephemeral: !ctx.isMessage()
+        });
+        return controller.stop();
+      }
+      const _perms = member.permissionsIn(ctx.channel as TextChannel);
+      if (needAllPerms && !_perms.has(perms)) {
+        await ctx.reply({
+          embeds: [
+            sendEmbed(response ?? `You cannot use this subcommand due to missing permissions: ${permsToString(perms)}`)
+          ],
+          ephemeral: !ctx.isMessage()
+        });
+        return controller.stop();
+      }
+      if (!needAllPerms && !_perms.any(perms)) {
+        await ctx.reply({
+          embeds: [
+            sendEmbed(
+              response ??
+                `You cannot use this subcommand because you need at least the following permissions: ${permsToString(
+                  perms
+                )}`
+            )
+          ],
+          ephemeral: !ctx.isMessage()
+        });
+        return controller.stop();
+      }
+    }
+    return controller.next();
+  });
 }
 function options(opts: BaseOptions[]) {
-	return CommandControlPlugin<CommandType.Slash>(async (ctx) => {
-		if (ctx.guild === null) {
-			await ctx.reply({
-				content: "This specific option cannot be used in DM's!",
-				ephemeral: !ctx.isMessage(),
-			});
-			return controller.stop();
-		}
-		const member = ctx.member as GuildMember;
-		const channel = ctx.channel as TextChannel;
+  return CommandControlPlugin<CommandType.Slash>(async (ctx) => {
+    if (ctx.guild === null) {
+      await ctx.reply({
+        content: "This specific option cannot be used in DM's!",
+        ephemeral: !ctx.isMessage()
+      });
+      return controller.stop();
+    }
+    const member = ctx.member as GuildMember;
+    const channel = ctx.channel as TextChannel;
 
-		for (const { name, needAllPerms, perms, response } of opts) {
-			const option = ctx.options.get(name);
+    for (const { name, needAllPerms, perms, response } of opts) {
+      const option = ctx.options.get(name);
 
-			if (option && option.name !== name) {
-				await ctx.reply({
-					embeds: [						
-						sendEmbed(`[PLUGIN_permCheck.options]: Could not find supplied option: \`${name}\``),
-					],
-					ephemeral: !ctx.isMessage(),
-				});
-				return controller.stop();
-			}
+      if (option && option.name !== name) {
+        await ctx.reply({
+          embeds: [sendEmbed(`[PLUGIN_permCheck.options]: Could not find supplied option: \`${name}\``)],
+          ephemeral: !ctx.isMessage()
+        });
+        return controller.stop();
+      }
 
-			const permissions = member.permissionsIn(channel);
+      const permissions = member.permissionsIn(channel);
 
-			if (needAllPerms) {
-				if (!permissions.has(perms)) {
-					await ctx.reply({
-						embeds: [
-							sendEmbed(response ??	`You need all the following permissions for option \`${name}\`:\n ${permsToString(...perms)}`),
-						],
-						ephemeral: !ctx.isMessage(),
-					});
-					return controller.stop();
-				}
-			} else {
-				if (!permissions.any(perms)) {
-					await ctx.reply({
-						embeds: [
-							sendEmbed(response ??	`You need at least one of the following permissions for option \`${name}\`: \n${permsToString(...perms)}`),
-						],
-						ephemeral: !ctx.isMessage(),
-					});
-					return controller.stop();
-				}
-			}
-		}
+      if (needAllPerms) {
+        if (!permissions.has(perms)) {
+          await ctx.reply({
+            embeds: [
+              sendEmbed(
+                response ??
+                  `You need all the following permissions for option \`${name}\`:\n ${permsToString(...perms)}`
+              )
+            ],
+            ephemeral: !ctx.isMessage()
+          });
+          return controller.stop();
+        }
+      } else {
+        if (!permissions.any(perms)) {
+          await ctx.reply({
+            embeds: [
+              sendEmbed(
+                response ??
+                  `You need at least one of the following permissions for option \`${name}\`: \n${permsToString(
+                    ...perms
+                  )}`
+              )
+            ],
+            ephemeral: !ctx.isMessage()
+          });
+          return controller.stop();
+        }
+      }
+    }
 
-		return controller.next();
-	});
+    return controller.next();
+  });
 }
 interface BaseOptions {
-	name: string;
-	perms: PermissionResolvable[];
-	needAllPerms: boolean;
-	response?: string;
+  name: string;
+  perms: PermissionResolvable[];
+  needAllPerms: boolean;
+  response?: string;
 }
 
 const sendEmbed = (description: string) => {
-	const client = Service("@sern/client");
-	return new EmbedBuilder({
-		title: ":x: Permission Error! :x:",
-		description,
-		color: Colors.Red,
-		footer: {
-			text: client.user?.username!,
-			icon_url: client.user?.displayAvatarURL()!,
-		},
-	});
+  const client = Service('@sern/client');
+  return new EmbedBuilder({
+    title: ':x: Permission Error! :x:',
+    description,
+    color: Colors.Red,
+    footer: {
+      text: client.user?.username!,
+      icon_url: client.user?.displayAvatarURL()!
+    }
+  });
 };
 
 export const permsToString = (...perms: PermissionResolvable[]) => {
-	return new PermissionsBitField(perms)
-		.toArray()
-		.map((perm) => `\`${perm}\``)
-		.join(", ");
+  return new PermissionsBitField(perms)
+    .toArray()
+    .map((perm) => `\`${perm}\``)
+    .join(', ');
 };
 
-export function permCheck(
-	type: "command",
-	perm: PermissionResolvable,
-	response?: string
-): ReturnType<typeof command>;
-
-export function permCheck(
-	type: "subGroups" | "subcommands" | "options",
-	opts: BaseOptions[]
-): | ReturnType<typeof subGroups>
-	 | ReturnType<typeof subcommands>
-	 | ReturnType<typeof options>;
-
-export function permCheck(
-	type: "command" | "subGroups" | "subcommands" | "options",
-	permissionsOrOpts: PermissionResolvable | BaseOptions[],
-	response?: string
-) {
-	switch (type) {
-		case "command":
-			return command(permissionsOrOpts as PermissionResolvable, response);
-		case "subGroups":
-			return subGroups(permissionsOrOpts as BaseOptions[]);
-		case "subcommands":
-			return subcommands(permissionsOrOpts as BaseOptions[]);
-		case "options":
-			return options(permissionsOrOpts as BaseOptions[]);
-		default:
-			throw new Error(`Unknown type: ${type}`);
-	}
+export function _permCheck(permissionsOrOpts: PermissionResolvable, response?: string) {
+  // permCheck function call is now a alias for command
+  return command(permissionsOrOpts as PermissionResolvable, response);
 }
+
+export const permCheck = Object.assign(_permCheck, {
+  command,
+  subGroups,
+  subcommands,
+  options
+});

--- a/plugins/permCheck.ts
+++ b/plugins/permCheck.ts
@@ -253,12 +253,7 @@ export const permsToString = (...perms: PermissionResolvable[]) => {
     .join(', ');
 };
 
-export function _permCheck(permissionsOrOpts: PermissionResolvable, response?: string) {
-  // permCheck function call is now a alias for command
-  return command(permissionsOrOpts as PermissionResolvable, response);
-}
-
-export const permCheck = Object.assign(_permCheck, {
+export const permCheck = Object.assign(command, {
   command,
   subGroups,
   subcommands,

--- a/plugins/permCheck.ts
+++ b/plugins/permCheck.ts
@@ -1,16 +1,24 @@
-// @ts-nocheck
+//@ts-nocheck
 /**
  * @plugin
  * This is perm check, it allows users to parse the permission you want and let the plugin do the rest. (check user for that perm).
+ * Each function (other than "command") allows multiple options! [ { ... }, { ... }, { ... } ] See examples!
  *
  * @author @Benzo-Fury [<@762918086349029386>]
- * @version 1.0.1
+ * @author @Peter-MJ-Parker [<@371759410009341952>]
+ * @version 2.0.0
  * @example
  * ```ts
  * import { permCheck } from "../plugins/permCheck";
  * import { commandModule } from "@sern/handler";
+ * import { PermissionFlagsBits } from "discord.js";
  * export default commandModule({
- *  plugins: [ permCheck('permission', 'No permission response') ],
+ *  plugins: [
+ * 		//permCheck.command("permission", "response")
+ * 		//permCheck.subGroups([{ name: "test", perms: <Permissions>, needAllPerms: boolean, response?: "set me for custom response"}, { ...other_group_setup }])
+ * 		//permCheck.subcommands([ { name: "testAgain", ...same options }, { ... } ])
+ * 		//permCheck.options([ {}, {} ]) WIP!
+ * 	],
  *  execute: (ctx) => {
  * 		//your code here
  *  }
@@ -19,21 +27,247 @@
  * @end
  */
 
-import type { GuildMember, PermissionResolvable } from "discord.js";
-import { CommandControlPlugin, CommandType, controller } from "@sern/handler";
-export function permCheck(perm: PermissionResolvable, response: string) {
-	return CommandControlPlugin<CommandType.Both>(async (ctx, args) => {
-		if (ctx.guild === null) {
-			await ctx.reply("This command cannot be used here");
-			console.warn(
-				"PermCheck > A command stopped because we couldn't check a users permissions (was used in dms)",
-			); //delete this line if you dont want to be notified when a command is used outside of a guild/server
-			return controller.stop();
-		}
-		if (!(ctx.member! as GuildMember).permissions.has(perm)) {
-			await ctx.reply(response);
-			return controller.stop();
-		}
-		return controller.next();
-	});
+import {
+  Colors,
+  EmbedBuilder,
+  PermissionsBitField,
+  type GuildMember,
+  type PermissionResolvable,
+  type TextChannel
+} from "discord.js";
+import {
+  CommandControlPlugin,
+  CommandType,
+  controller,
+  Service
+} from "@sern/handler";
+
+function command(perm: PermissionResolvable, response?: string) {
+  return CommandControlPlugin<CommandType.Both>(async (ctx) => {
+    if (ctx.guild === null) {
+      await ctx.reply("This command cannot be used in DM's!");
+      return controller.stop();
+    }
+    if (
+      !(ctx.member! as GuildMember)
+        .permissionsIn(ctx.channel as TextChannel)
+        .has(perm)
+    ) {
+      await ctx.reply({
+        embeds: [
+          sendEmbed(
+            response ??
+              `You are missing required permissions to run this command:\n${permsToString(perm)}`
+          )
+        ],
+        ephemeral: ctx.isMessage() ? false : true
+      });
+      return controller.stop();
+    }
+    if (
+      !(ctx.member! as GuildMember)
+        .permissionsIn(ctx.channel as TextChannel)
+        .any(perm)
+    ) {
+      await ctx.reply({
+        embeds: [
+          sendEmbed(
+            response ??
+              `You need at least one of the following permissions to run this command:\n${permsToString(perm)}`
+          )
+        ],
+        ephemeral: ctx.isMessage() ? false : true
+      });
+      return controller.stop();
+    }
+    return controller.next();
+  });
 }
+function subGroups(opts: BaseOptions[]) {
+  return CommandControlPlugin<CommandType.Slash>(async ({ interaction }) => {
+    await no_guild(interaction);
+    const member = interaction.member as GuildMember;
+    const group = interaction.options.getSubcommandGroup();
+    for (const opt of opts) {
+      if (group !== opt.name) {
+        await interaction.reply({
+          embeds: [
+            sendEmbed(
+              `[PLUGIN_permCheck.subGroups]: Failed to find specified subcommandGroup \`${opt.name}\`!`
+            )
+          ],
+          ephemeral: true
+        });
+        return controller.stop();
+      }
+      const _perms = member.permissionsIn(interaction.channel as TextChannel);
+      if (opt.needAllPerms && !_perms.has(opt.perms)) {
+        await interaction.reply({
+          embeds: [
+            sendEmbed(
+              opt.response ??
+                `You cannot use this group due to missing permissions: ${permsToString(opt.perms)}`
+            )
+          ],
+          ephemeral: true
+        });
+        return controller.stop();
+      }
+      if (!opt.needAllPerms && !_perms.any(opt.perms)) {
+        await interaction.reply({
+          embeds: [
+            sendEmbed(
+              opt.response ??
+                `You cannot use this group because you need at least one of the following permissions: ${permsToString(opt.perms)}`
+            )
+          ],
+          ephemeral: true
+        });
+        return controller.stop();
+      }
+    }
+    return controller.next();
+  });
+}
+
+function subcommands(opts: BaseOptions[]) {
+  return CommandControlPlugin<CommandType.Slash>(async ({ interaction }) => {
+    await no_guild(interaction);
+    const member = interaction.member as GuildMember;
+    const sub = interaction.options.getSubcommand();
+    for (const opt of opts) {
+      if (sub !== opt.name) {
+        await interaction.reply({
+          embeds: [
+            sendEmbed(
+              `[PLUGIN_permCheck.subcommands]: Failed to find specified subcommand \`${opt.name}\`!`
+            )
+          ],
+          ephemeral: true
+        });
+        return controller.stop();
+      }
+      const _perms = member.permissionsIn(interaction.channel as TextChannel);
+      if (opt.needAllPerms && !_perms.has(opt.perms)) {
+        await interaction.reply({
+          embeds: [
+            sendEmbed(
+              opt.response ??
+                `You cannot use this subcommand due to missing permissions: ${permsToString(opt.perms)}`
+            )
+          ],
+          ephemeral: true
+        });
+        return controller.stop();
+      }
+      if (!opt.needAllPerms && !_perms.any(opt.perms)) {
+        await interaction.reply({
+          embeds: [
+            sendEmbed(
+              opt.response ??
+                `You cannot use this subcommand because you need at least one of the following permissions: ${permsToString(opt.perms)}`
+            )
+          ],
+          ephemeral: true
+        });
+        return controller.stop();
+      }
+    }
+    return controller.next();
+  });
+}
+function options(opts: BaseOptions[]) {
+  return CommandControlPlugin<CommandType.Slash>(async ({ interaction }) => {
+    await no_guild(interaction);
+    const member = interaction.member as GuildMember;
+    const channel = interaction.channel as TextChannel;
+
+    for (const opt of opts) {
+      const option = interaction.options.get(opt.name);
+      console.log(option);
+
+      if (option && option.name !== opt.name) {
+        await interaction.reply({
+          embeds: [
+            sendEmbed(
+              `[PLUGIN_permCheck.options]: Could not find supplied option: \`${opt.name}\``
+            )
+          ],
+          ephemeral: true
+        });
+        return controller.stop();
+      }
+
+      const permissions = member.permissionsIn(channel);
+
+      console.log(permsToString(permissions));
+      if (opt.needAllPerms) {
+        if (!permissions.has(opt.perms)) {
+          await interaction.reply({
+            embeds: [
+              sendEmbed(
+                opt.response ??
+                  `You need all the following permissions for option \`${opt.name}\`:\n ${permsToString(...opt.perms)}`
+              )
+            ],
+            ephemeral: true
+          });
+          return controller.stop();
+        }
+      } else {
+        if (!permissions.any(opt.perms)) {
+          await interaction.reply({
+            embeds: [
+              sendEmbed(
+                opt.response ??
+                  `You need at least one of the following permissions for option \`${opt.name}\`: \n${permsToString(...opt.perms)}`
+              )
+            ],
+            ephemeral: true
+          });
+          return controller.stop();
+        }
+      }
+    }
+
+    return controller.next();
+  });
+}
+interface BaseOptions {
+  name: string;
+  perms: PermissionResolvable[];
+  needAllPerms: boolean;
+  response?: string;
+}
+
+const no_guild = async (interaction: any) => {
+  if (interaction.guild === null) {
+    await interaction.reply({
+      content: "This command cannot be used in DM's!",
+      ephemeral: true
+    });
+    return controller.stop();
+  }
+};
+
+const sendEmbed = (description: string) => {
+  const client = Service("@sern/client");
+  return new EmbedBuilder({
+    title: ":x: Permission Error! :x:",
+    description,
+    color: Colors.Red,
+    footer: {
+      text: client.user?.username!,
+      icon_url: client.user?.displayAvatarURL()!
+    }
+  });
+};
+
+export const permsToString = (...perms: PermissionResolvable[]) => {
+  return new PermissionsBitField(perms)
+    .toArray()
+    .map((perm) => `\`${perm}\``)
+    .join(", ");
+};
+
+export const permCheck = { command, options, subcommands, subGroups };


### PR DESCRIPTION
Allows users to check member perms before using specific sub command groups, sub commands, and options!

## Plugin Submission Checklist

Before submitting your plugin, please ensure that you have followed the specifications below:

- [x] Your plugin code includes a JSDoc block with `@plugin` at the beginning and `@end` at the end.
- [x] The order of plugin metadata within the JSDoc block follows the structure provided:
  1. `@plugin`
  2. `description`
  3. `@author` (you can have multiple authors in this format: `@author  @jacoobes [<@182326315813306368>]`)
  4. `@version` (with the version number)
  5. `@example` (a nice example of how to use your plugin)
  6. `@end`

this is an example:
```js
/** 
 * @plugin
 * filters autocomplete interaction that pass the criteria
 * @author @jacoobes [<@182326315813306368>]
 * @version 1.0.0
 * @example
 * ```ts
 * import { CommandType, commandModule } from "@sern/handler";
 * import { filterA } from '../plugins/filterA.js'
 * export default commandModule({
 *    type : CommandType.Slash,
 *    options: [
 *       {  
 *          autocomplete: true,
 *          command : {
 *             //only accept autocomplete interactions that include 'poo' in the text
 *             onEvent: [filterA(s => s.includes('poo'))],
 *             execute: (autocomplete) => {
 *                let data = [{ name: 'pooba', value: 'first' }, { name: 'pooga', value: 'second' }]
 *                autocomplete.respond(data) 
 *             }
 *          }
 *       }
 *    ],
 *    execute: (ctx, args) => {}
 * })
 * @end
 */


```

## Plugin Submission Details
Allows users to dynamically require certain permissions to use separate subcommands, subcommand groups, and hoisted options.
## Additional Notes
Reverted the original function and changed the parameters up a bit.
